### PR TITLE
fix: Fix to use python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.11
 
 ARG command="--version"
 


### PR DESCRIPTION
`python:3` have been changed to use Python 3.12.
https://github.com/docker-library/python/commit/b7b91ef359a740a91caeabce414ce4ee70fd2b23

And Python 3.12 removes `imp` module which is used by eb-cli.
https://docs.python.org/3.12/whatsnew/3.12.html